### PR TITLE
udpated-rewardMember-function

### DIFF
--- a/contract.sol
+++ b/contract.sol
@@ -97,10 +97,11 @@ contract TokenReward {
         return true;
     }
     
-    function rewardMember(address __memberToReward) public OnlyAdminOrOwner returns(bool) {
+    function rewardMember(address __memberToReward, uint8 __rewardAmount) public OnlyAdminOrOwner returns(bool) {
         require(admins[__memberToReward] == false, "admins cannot be rewarded tokens");
         require(members[__memberToReward].rating >= 3, "member do not have a proven track record");
-        balances[__memberToReward] = balances[__memberToReward] + 2;
+        require(__rewardAmount <= 2, "Not more than 2 tokens can be rewarded");
+        balances[__memberToReward] = balances[__memberToReward] + __rewardAmount;
         return true;
     }
     


### PR DESCRIPTION
From the token's description, no more than 2 tokens can be rewarded at a time. Added the option for admins to send rewards lower than 2 to encourage participants with decent effort